### PR TITLE
feat(stats): add stats() function and CLI command

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,38 @@ def log(subject: str) -> str:
     _save(data)
     return today
 
+def stats():
+    """Return a dict with total unique study days and longest consecutive streak."""
+    data = _load()
+    by_day = {}
+
+    # Count study sessions per day
+    for entry in data["logs"]:
+        by_day.setdefault(entry["date"], 0)
+        by_day[entry["date"]] += 1
+
+    if not by_day:
+        return {"days": 0, "streak": 0}
+
+    # Sort days in ascending order
+    all_days = sorted(by_day.keys())
+
+    from datetime import datetime, timedelta
+
+    def to_dt(s): 
+        return datetime.fromisoformat(s).date()
+
+    streak = best = 1
+    for i in range(1, len(all_days)):
+        if to_dt(all_days[i]) == to_dt(all_days[i-1]) + timedelta(days=1):
+            streak += 1
+            best = max(best, streak)
+        else:
+            streak = 1
+
+    return {"days": len(by_day), "streak": best}
+
+
 def main():
     parser = argparse.ArgumentParser(description="Study Streak Tracker")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -30,10 +62,18 @@ def main():
     p_log.add_argument("subject", help="What you studied (e.g., 'calculus')")
 
     args = parser.parse_args()
+    sub.add_parser("stats", help="Show total days studied and longest streak")
 
     if args.cmd == "log":
         d = log(args.subject)
         print(f"Logged {args.subject!r} for {d}")
+    elif args.cmd == "stats":
+        s = stats()
+        print(f"Days logged: {s['days']} | Best streak: {s['streak']}")
+
+        print(f"Logged {args.subject!r} for {d}")
+    
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import json
+import app
+
+def test_stats_calculates_days_and_streak(tmp_path, monkeypatch):
+    # Redirect to a temporary file for safety
+    monkeypatch.setattr(app, "DATA_PATH", tmp_path / "streak_data.json")
+
+    # Create fake data with gaps
+    fake_data = {
+        "logs": [
+            {"date": "2025-09-01", "subject": "calculus"},
+            {"date": "2025-09-02", "subject": "physics"},
+            {"date": "2025-09-04", "subject": "programming"},
+            {"date": "2025-09-05", "subject": "biology"},
+        ]
+    }
+
+    # Save fake data
+    Path(app.DATA_PATH).write_text(json.dumps(fake_data))
+
+    # Run stats()
+    result = app.stats()
+
+    assert result["days"] == 4          # 4 unique days
+    assert result["streak"] == 2        # Best streak = 2 consecutive days (Sep 1-2)


### PR DESCRIPTION
- Adds stats() to calculate total study days and longest consecutive streak.
- CLI command: python app.py stats
- Includes unit test for accuracy.
