### PR TITLE
feat(list): add list_logs() and CLI to display logs newest-first

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,15 @@ def stats():
 
     return {"days": len(by_day), "streak": best}
 
+def list_logs():
+    """Return logs sorted by date descending."""
+    data = _load()
+    items = data.get("logs", [])
+    # sort ISO dates descending; ISO sorts lexicographically by date safely
+    items_sorted = sorted(items, key=lambda x: x["date"], reverse=True)
+    return items_sorted
+
+
 
 def main():
     parser = argparse.ArgumentParser(description="Study Streak Tracker")
@@ -64,6 +73,9 @@ def main():
 
     # stats
     sub.add_parser("stats", help="Show total days studied and longest streak")
+    # after existing subcommands
+    sub.add_parser("list", help="Show all study logs (newest first)")
+
 
     args = parser.parse_args()
 
@@ -73,6 +85,9 @@ def main():
     elif args.cmd == "stats":
         s = stats()
         print(f"Days logged: {s['days']} | Best streak: {s['streak']}")
+    elif args.cmd == "list":
+        for item in list_logs():
+            print(f"{item['date']} | {item['subject']}")
 
     
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import json
+import app
+
+def test_list_returns_logs_sorted_desc(tmp_path, monkeypatch):
+    # use a temp data file
+    monkeypatch.setattr(app, "DATA_PATH", tmp_path / "streak_data.json")
+
+    # seed fake data (unsorted)
+    fake = {
+        "logs": [
+            {"date": "2025-09-01", "subject": "calculus"},
+            {"date": "2025-09-03", "subject": "physics"},
+            {"date": "2025-09-02", "subject": "programming"},
+        ]
+    }
+    Path(app.DATA_PATH).write_text(json.dumps(fake))
+
+    items = app.list_logs()
+    # should be newest first (desc by date)
+    assert [i["date"] for i in items] == ["2025-09-03", "2025-09-02", "2025-09-01"]
+    assert items[0]["subject"] == "physics"


### PR DESCRIPTION
- Adds `list_logs()` function to return study logs sorted by date descending.
- Adds CLI command: `python app.py list`
- Displays logs in `YYYY-MM-DD | Subject` format.
- Includes unit tests to verify sorting and output.
